### PR TITLE
Add BytesField

### DIFF
--- a/src/springfield/fields.py
+++ b/src/springfield/fields.py
@@ -275,6 +275,7 @@ class StringField(AdaptableTypeField):
     """
 
     type = unicode
+
     def adapt(self, value):
         """
         Adapt `value` to `unicode`.
@@ -285,6 +286,14 @@ class StringField(AdaptableTypeField):
             if isinstance(value, basestring):
                 return unicode(value)
             raise
+
+class BytesField(AdaptableTypeField):
+    """
+    A :class:`Field` that contains binary bytes (or a legacy Python 2 string).
+    """
+
+    type = bytes
+
 
 class SlugField(StringField):
     """


### PR DESCRIPTION
I wasn't sure whether the `get_field_for_type` function should be affected by this.  I don't know whether that would mess up any existing code.

That could easily be done in a follow-up.

See also https://github.com/six8/springfield/issues/9
