### PR TITLE
Fix pip install commands for travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "2.6"
   - "2.7"
 install:
-  - "pip install pytest --use-mirrors"
-  - "pip install . --use-mirrors"  
-  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install pytest"
+  - "pip install ."
+  - "pip install -r requirements.txt"
 script:
   - sh -c 'cd src && python tests/runtests.py -v'


### PR DESCRIPTION
- Remove use of `--use-mirrors` flag for PIP which is removed in pip 9.x

I'm getting this error on some other PRs:

```
0.76s$ git clone --depth=50 https://github.com/six8/springfield.git six8/springfield
Cloning into 'six8/springfield'...
remote: Counting objects: 244, done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 244 (delta 3), reused 11 (delta 3), pack-reused 233
Receiving objects: 100% (244/244), 41.81 KiB | 0 bytes/s, done.
Resolving deltas: 100% (106/106), done.
Checking connectivity... done.
$ cd six8/springfield
0.61s$ git fetch origin +refs/pull/14/merge:
remote: Counting objects: 11, done.
remote: Total 11 (delta 7), reused 7 (delta 7), pack-reused 3
Unpacking objects: 100% (11/11), done.
From https://github.com/six8/springfield
 * branch            refs/pull/14/merge -> FETCH_HEAD
$ git checkout -qf FETCH_HEAD
0.01s$ source ~/virtualenv/python2.6/bin/activate
$ python --version
Python 2.6.9
$ pip --version
pip 9.0.1 from /home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages (python 2.6)
0.39s$ pip install pytest --use-mirrors
Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...
no such option: --use-mirrors
The command "pip install pytest --use-mirrors" failed and exited with 2 during .
Your build has been stopped.
```

I don't know how to test this change locally, so I'm opening this PR hoping the CI build will succeed and that suffices as my test :P